### PR TITLE
fix link typo

### DIFF
--- a/src/views/welcome.svelte
+++ b/src/views/welcome.svelte
@@ -106,7 +106,7 @@
         <div>
             <p>
                 Next up, <em
-                    ><strong><a href="/docs/form-types">Form Types</a></strong
+                    ><strong><a href="/docs/form_types">Form Types</a></strong
                     ></em
                 >. Discover all form and field configuration options!
             </p>


### PR DESCRIPTION
The link at the end of the welcome section should be  `/docs/form_types` instead of `/docs/form-types`