### PR TITLE
bugfix: redact misbehaving in groups

### DIFF
--- a/src/components/Edit/EditField.svelte
+++ b/src/components/Edit/EditField.svelte
@@ -464,7 +464,7 @@
                     meta: {
                         uid: "edit",
                         name: "Edit",
-                        group: { label: true, feedback: true },
+                        override: { label: true, feedback: true },
                     },
                     add: {
                         uid: "add",
@@ -581,7 +581,7 @@
                     meta: {
                         uid: "icon",
                         name: "icon",
-                        group: { label: true, feedback: true },
+                        override: { label: true, feedback: true },
                     },
                     off: {
                         uid: "off",

--- a/src/lib/components/Form.svelte
+++ b/src/lib/components/Form.svelte
@@ -439,7 +439,7 @@
 			setEntry(
 				uid,
 				"redact",
-				g ? g.redact : field.redact,
+				(g && g.redact) || field.redact,
 				field.uid,
 				g?.uid
 			);

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -40,7 +40,7 @@ export function newType(type: string, uid: string): Field | Group {
             meta: {
                 uid,
                 name: `new group`,
-                group: { label: true, feedback: true },
+                override: { label: true, feedback: true },
             },
             [textUID]: {
                 uid: textUID,


### PR DESCRIPTION
fields marked redacted that belong to a group fail to "un-redact" when in focus

- other minor bugfixes came from renaming group to override. not everything was correctly renamed.